### PR TITLE
be compatible with R4.1

### DIFF
--- a/R/geom_segment_c.R
+++ b/R/geom_segment_c.R
@@ -127,14 +127,14 @@ setup_data_continuous_color_df <- function(df, nsplit = 100, extend = 0.002, poo
                                            extend = extend)
 
         res <- lapply(df[i,, drop = FALSE], rep, each = nrow(df2)) |>
-            do.call('cbind', args = _) |> as.data.frame()
+            do.call('cbind', args = list()) |> as.data.frame()
         res$x <- df2$x
         res$xend <- df2$xend
         res$y <- df2$y
         res$yend <- df2$yend
         res$colour <- df2$col
         return(res)
-    }) |> do.call('rbind', args = _)
+    }) |> do.call('rbind', args = list())
 }
 
 


### PR DESCRIPTION
the `do.call('cbind', args = _)` seem not be compatible with R4.1

```
> remotes::install_github('YuLab-SMU/ggfun')
Downloading GitHub repo YuLab-SMU/ggfun@HEAD
✔  checking for file ‘/tmp/RtmpqdlCtp/remotes369870f87e0/YuLab-SMU-ggfun-54535b9/DESCRIPTION’ (382ms)
─  preparing ‘ggfun’:
✔  checking DESCRIPTION meta-information ...
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
─  building ‘ggfun_0.1.0.tar.gz’

* installing *source* package ‘ggfun’ ...
** using staged installation
** R
Error in parse(outFile) :
  /tmp/RtmpnaopuQ/R.INSTALL36d55af77ed2/ggfun/R/geom_segment_c.R:130:37: unexpected input
129:         res <- lapply(df[i,, drop = FALSE], rep, each = nrow(df2)) |>
130:             do.call('cbind', args = _
                                         ^
ERROR: unable to collate and parse R files for package ‘ggfun’
* removing ‘/mnt/d/UbuntuApps/R/4.1.2/lib/R/library/ggfun’
* restoring previous ‘/mnt/d/UbuntuApps/R/4.1.2/lib/R/library/ggfun’
Warning message:
In i.p(...) :
  installation of package ‘/tmp/RtmpqdlCtp/file36985330d1f9/ggfun_0.1.0.tar.gz’ had non-zero exit status
```